### PR TITLE
Read content from the stream, not from the filesystem

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,12 @@ module.exports = function(opt){
             opt = {};
         }
 
+        // 'url' option is required
+        // set it automatically if not provided
+        if(!opt.url) {
+            opt.url = 'file://' + file.path;
+        }
+
         if (file.isNull()) {
             this.push(file);
             return cb();
@@ -20,7 +26,7 @@ module.exports = function(opt){
             return cb();
         }
 
-        juice(file.path, opt, function (err, html) {
+        juice.juiceContent(file.contents, opt, function(err, html) {
             if (err) {
                 this.emit('error', new gutil.PluginError('gulp-inline-css', err));
             }

--- a/test/main.js
+++ b/test/main.js
@@ -9,7 +9,7 @@ var inlineCss = require('../index');
 
 function compare(input, options, done) {
     var fakeFile = new gutil.File({
-        path: './test/fixtures/in.html',
+        path: path.resolve('./test/fixtures/in.html'),
         cwd: './test/',
         base: './test/fixtures/',
         contents: new Buffer(String(input))


### PR DESCRIPTION
Hi there,

I wrote a similar plugin before, and you fell into the same trap as I did - reading content from the filesystem versus from the stream.

As of now, if you modify the stream before passing it to gulp-inline-css (let's say, using gulp-replace), the modifications will be lost as gulp-inline-css reads its data from the filesystem (using file.path within its juice call).

Using juice.juiceContent() fixes that issue and actually deals with the stream content.

Let me know if my explanation is clear enough, thanks.
