### PR TITLE
Fix for inlineCss version 2.3.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (opt) {
             return;
         }
 
-        inlineCss(file.contents, _opt)
+        inlineCss(file.contents.toString('utf8'), _opt)
             .then(function (html) {
                 file.contents = new Buffer(String(html));
 


### PR DESCRIPTION
Since version 2.3.0 uses replace (which requires a string) the
file.contents buffer is now explicitly converted to a string prior to
the inlining.